### PR TITLE
do not expose gitpod/workspace-id in hostname

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,8 @@ tasks:
       sudo tailscaled
   - name: tailscale
     command: |
-      sudo -E tailscale up --hostname "gitpod-${GITPOD_WORKSPACE_ID}" \
+      # hostname = gitpod_<user>_<org>_<repo>
+      sudo -E tailscale up --hostname "gitpod_${GITPOD_GIT_USER_NAME}_$(echo $GITPOD_WORKSPACE_CONTEXT | jq -r .repository.owner)_$(echo ${GITPOD_WORKSPACE_CONTEXT} | jq -r .repository.name)" \
                            --authkey "${TAILSCALE_AUTHKEY}"
 
 experimentalNetwork: true


### PR DESCRIPTION
## Description
Tailscale docs explicitly [state](https://tailscale.com/kb/1153/enabling-https/):
> Do not enable the HTTPS feature if any of your machine names contain sensitive information.

Exposing Gitpod Workspace ID in hostname can ponentially lead to an exploit, given:
* Workspace is marked as "Shared", enabling full access via Workspace ID + region (which is easy to guess)
* Tailscale HTTPS certificate is issued for this Workspace, so hostname is published to CT public ledger (maybe even auto-published by just enabling HTTPS feature? doesn't seem to be the case right now though)

This PR replaces hostname with still meaningful by less sensitive info.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
