### PR TITLE
Keep machine state across workspaces

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,10 +3,18 @@ image:
 tasks:
   - name: tailscaled
     command: |
+      if [ -n "${TS_STATE_TAILSCALE_EXAMPLE}" ]; then
+        # restore the tailscale state from gitpod user's env vars
+        sudo mkdir -p /var/lib/tailscale
+        echo "${TS_STATE_TAILSCALE_EXAMPLE}" | sudo tee /var/lib/tailscale/tailscaled.state > /dev/null
+      fi
       sudo tailscaled
   - name: tailscale
     command: |
-      sudo -E tailscale up --hostname "gitpod-${GITPOD_GIT_USER_NAME// /-}-$(echo ${GITPOD_WORKSPACE_CONTEXT} | jq -r .repository.name)" \
-                           --authkey "${TAILSCALE_AUTHKEY}"
-
-experimentalNetwork: true
+      if [ -n "${TS_STATE_TAILSCALE_EXAMPLE}" ]; then
+        sudo -E tailscale up
+      else
+        sudo -E tailscale up --hostname "gitpod-${GITPOD_GIT_USER_NAME// /-}-$(echo ${GITPOD_WORKSPACE_CONTEXT} | jq -r .repository.name)"
+        # store the tailscale state into gitpod user
+        gp env TS_STATE_TAILSCALE_EXAMPLE="$(sudo cat /var/lib/tailscale/tailscaled.state)"
+      fi

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ tasks:
       sudo tailscaled
   - name: tailscale
     command: |
-      sudo -E tailscale up --hostname "gitpod-${GITPOD_WORKSPACE_ID}" \
+      sudo -E tailscale up --hostname "gitpod-${GITPOD_GIT_USER_NAME// /-}-$(echo ${GITPOD_WORKSPACE_CONTEXT} | jq -r .repository.name)" \
                            --authkey "${TAILSCALE_AUTHKEY}"
 
 experimentalNetwork: true


### PR DESCRIPTION
This setup will store the machine state per user/repo. As a result, new workspaces will have the same node name and therefore be reachable using a stable URL. The machine information is stored securely in Gitpod's user secrets store.

### What it does.

On workspace start it checks a certain env var (passed in from your gitpod user profile). If it exists it copies its contents into `/var/lib/tailscale/tailscaled.state`.

On after tailscale has started and established a connection, it stores the contents of `/var/lib/tailscale/tailscaled.state` in the respective env var in your Gitpod profile.


### How to test

1. create a Tailscale account 
1. [Start a workspace from this PR](https://gitpod.io/#https://github.com/gitpod-io/template-tailscale/pull/6), login (see link in console) and wait for the connection to be established. Find a new node `gitpod-your-name-teamplate-tailscale` in your [tailscale dashboard](https://login.tailscale.com/admin/machines). 
1. Stop the workspace and verify the node is disconnected.
1. [Start a new workspace from this PR](https://gitpod.io/#https://github.com/gitpod-io/template-tailscale/pull/6) and see that the same node is reused. 
(*Note:* it does not work unfortunately, instead a new node is created 😬 )
