### PR TITLE
Use ip6tables-nft

### DIFF
--- a/gitpod.Dockerfile
+++ b/gitpod.Dockerfile
@@ -6,3 +6,4 @@ RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | sudo apt-key
      && curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.list | sudo tee /etc/apt/sources.list.d/tailscale.list \
      && apt-get update \
      && apt-get install -y tailscale
+RUN update-alternatives --set ip6tables /usr/sbin/ip6tables-nft


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/8049

Signed-off-by: Denton Gentry <dgentry@tailscale.com>

## Description
Set ip6tables-nft as the implementation for ip6tables.

## Related Issue(s)
Fixes #8049

## How to test
https://gitpod.io/#https://github.com/DentonGentry/template-tailscale

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
!Fix Tailscale MagicDNS handling
```

## Documentation
No